### PR TITLE
Améliorer la capacité d'héritage de Crue10_tools

### DIFF
--- a/crue10/etude.py
+++ b/crue10/etude.py
@@ -12,6 +12,7 @@ from crue10.run import Run
 from crue10.scenario import Scenario
 from crue10.sous_modele import SousModele
 from crue10.utils import check_isinstance, ExceptionCrue10, logger, PREFIX
+from crue10.utils.design_patterns import factory_define, factory_make
 
 
 def read_metadata(elt, keys):
@@ -22,6 +23,7 @@ def read_metadata(elt, keys):
     return metadata
 
 
+@factory_define('Etude')                        # Cette classe pourra être appelée par factory_make('Etude')
 class Etude(EnsembleFichiersXML):
     """
     Étude Crue10
@@ -251,7 +253,7 @@ class Etude(EnsembleFichiersXML):
                         raise NotImplementedError  # A single Modele for a Scenario!
 
                 metadata = read_metadata(elt_scenario, Scenario.METADATA_FIELDS)
-                scenario = Scenario(nom_scenario, modele, files=files, metadata=metadata,
+                scenario = factory_make('Scenario')(nom_scenario, modele, files=files, metadata=metadata,
                                     version_grammaire=self.version_grammaire)
 
                 runs = elt_scenario.find(PREFIX + 'Runs')
@@ -421,7 +423,7 @@ class Etude(EnsembleFichiersXML):
                         version_grammaire=version_grammaire)
         if nom_sous_modele is not None:
             modele.create_empty_sous_modele(nom_sous_modele, self.mode, metadata=metadata)
-        scenario = Scenario(nom_scenario, modele, mode=self.mode, metadata=metadata,
+        scenario = factory_make('Scenario')(nom_scenario, modele, mode=self.mode, metadata=metadata,
                             version_grammaire=version_grammaire)
         self.ajouter_scenario(scenario)
         if not self.nom_scenario_courant:
@@ -597,7 +599,7 @@ class Etude(EnsembleFichiersXML):
             out_path = os.path.join(self.folder, nom_scenario_cible[3:] + '.' + xml_type + '.xml')
             copyfile(in_path, out_path)
             scenario_files[xml_type] = out_path  # overwrite Scenario file path
-        scenario = Scenario(nom_scenario_cible, scenario_ori.modele, mode='w',
+        scenario = factory_make('Scenario')(nom_scenario_cible, scenario_ori.modele, mode='w',
                             files=scenario_files, metadata=scenario_ori.metadata)
         scenario.read_all()
         if overwrite and scenario.id in self.scenarios:

--- a/crue10/scenario/__init__.py
+++ b/crue10/scenario/__init__.py
@@ -16,6 +16,7 @@ from crue10.utils import check_isinstance, check_preffix, check_xml_content, \
     duration_iso8601_to_seconds, duration_seconds_to_iso8601, \
     ExceptionCrue10, extract_pdt_from_elt, get_optional_commentaire, get_xml_root_from_file, \
     JINJA_ENV, logger, parse_loi, PREFIX, write_default_xml_file, write_xml_from_tree, DATA_FOLDER_ABSPATH
+from crue10.utils.design_patterns import factory_define, factory_make
 from crue10.utils.crueconfigmetier import CCM_FILE
 from crue10.utils.settings import CRUE10_EXE_PATH
 from crue10.utils.sorties import Sorties
@@ -99,6 +100,7 @@ class OrdCalcTrans:
             return res
 
 
+@factory_define('Scenario')                     # Cette classe pourra être appelée par factory_make('Scenario')
 class Scenario(EnsembleFichiersXML):
     """
     Scénario Crue10
@@ -207,8 +209,8 @@ class Scenario(EnsembleFichiersXML):
         """
         Ajouter une loi hydraulique au scénario
 
-        :param run: loi hydraulique à ajouter
-        :type run: LoiHydraulique
+        :param loi_hydraulique: loi hydraulique à ajouter
+        :type loi_hydraulique: LoiHydraulique
         """
         check_isinstance(loi_hydraulique, LoiHydraulique)
         self.lois_hydrauliques[loi_hydraulique.id] = loi_hydraulique
@@ -751,13 +753,13 @@ class Scenario(EnsembleFichiersXML):
         run.launch_services(Run.SERVICES, exe_path=exe_path)
         return run
 
-    def create_and_launch_new_multiple_sequential_runs(self, modifications_liste, etude,
-                                                       exe_path=CRUE10_EXE_PATH, force=False):
+    def create_and_launch_new_multiple_sequential_runs(
+            self, modifications_liste, etude, exe_path=CRUE10_EXE_PATH, force=False):
         """
         Créer et lancer des runs séquentiels selon les modifications demandées
 
-        :param modifications: liste avec les dictionnaires contenant les modifications
-        :type modifications: list(dict(str))
+        :param modifications_liste: liste avec les dictionnaires contenant les modifications
+        :type modifications_liste: list(dict(str))
         :param etude: étude courante
         :type etude: Etude
         :param exe_path: chemin vers l'exécutable crue10.exe

--- a/crue10/utils/design_patterns.py
+++ b/crue10/utils/design_patterns.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+
+"""
+Ensemble d'utilitaires mettant en œuvre divers design patterns.
+- Singleton
+- Factory
+© CNR
+PBa 2025-06 Création
+"""
+
+
+class Singleton(type):
+    """ Classe à utiliser comme une métaclasse pour mettre en œuvre le design pattern Singleton.
+    Cela permet d'instancier une classe à divers endroits du code, en n'en ayant qu'une seule et unique instance.
+    """
+    # Variable de classe: dictionnaire des instances {}
+    _dic_nom_obj = {}
+
+    def __call__(cls, *args, **kwargs):
+        """ Fournir une instance de la classe, en la créant seulement la première fois.
+        """
+        if cls not in cls._dic_nom_obj:
+            cls._dic_nom_obj[cls] = super(Singleton, cls).__call__(*args, **kwargs)  # Appeler le constructeur, une fois
+        return cls._dic_nom_obj[cls]            # Renvoyer une instance déjà créée
+
+
+class FactoryClass(metaclass=Singleton):
+    """ Classe utilitaire mettant en œuvre le design pattern Factory.
+    Cela permet de récupérer une classe associée à un nom, pour ensuite l'instancier en late binding. On peut ainsi
+    spécialiser une classe de Crue10_tools dans un autre package, sans toucher à Crue10_tools.
+    Ensemble cohérent: 'FactoryClass', 'factory_define', 'factory_make' (les deux fonctions constituent l'interface).
+    """
+    # Variable de classe: dictionnaire d'association {nom_cls: cls}
+    _dic_nom_cls = {}
+
+    def define(self, nom_cls: str, cls: callable) -> None:
+        """ Définir une association entre un nom et une classe.
+        :param nom_cls: nom associé
+        :param cls: classe à utiliser
+        """
+        # print(f"Définir '{nom_cls}' comme {cls}")
+        self._dic_nom_cls[nom_cls] = cls
+
+    def make(self, nom_cls: str) -> callable:
+        """ Fournir la classe à partir du nom qui lui est associé.
+        :param nom_cls: nom associé
+        :return: classe à utiliser
+        """
+        # print(f"Utiliser '{nom_cls}' comme {self._dic_nom_cls.get(nom_cls)}")
+        return self._dic_nom_cls.get(nom_cls)
+
+
+def factory_define(nom_cls: str):
+    """ Décorateur qui associe le nom passé en paramètre à la classe décorée; pour ensuite utiliser 'factory'.
+    Ensemble cohérent: 'FactoryClass', 'factory_define', 'factory_make'.
+    :param nom_cls: nom associé à la classe
+    """
+    def decorator(cls: callable):
+        """ Récupérer la classe décorée pour pouvoir l'utiliser via 'factory'.
+        :param cls: classe décorée
+        :return: classe définie
+        """
+        FactoryClass().define(nom_cls, cls)     # Mémoriser l'association entre nom_cls et cls
+        return cls
+    return decorator
+
+
+def factory_make(nom_cls: str) -> callable:
+    """ Renvoyer la classe associée à un nom; utiliser le décorateur '@factory_define' sur la classe pour l'associer.
+    Ensemble cohérent: 'FactoryClass', 'factory_define', 'factory_make'.
+    Exemple d'utilisation: etu = factory_make('Etude')(etu_path=r"path/to/Etu_XX.etu.xml")
+    :param nom_cls: nom associé à la classe à renvoyer
+    :return: classe associée
+    """
+    return FactoryClass().make(nom_cls)


### PR DESCRIPTION
Le but est de pouvoir spécialiser des comportements de `Etude`, `Scenario `(et potentiellement `Modele`, `SousModele`, `Run`, _etc_.) dans des projets utilisant Crue10_tools, sans polluer le projet commun.

Cela s'appuie sur le design pattern Factory:
- déclaration d'une association entre un nom (chaîne, par exemple `'Scenario'`) et une classe d'implémentation (par exemple `crue10.scenario.Scenario` par défaut, ou une classe spécialisée `mon_projet.SpecializedScenario` héritant de `Scenario`) _via_ le décorateur **factory_define**.
- appel de la classe souhaitée dans le code utilisateur par ce nom, _via_ la fonction utilitaire **factory_make**.