### PR TITLE
Limiter utilisation de lxml et préparation v4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,18 @@ Journal des modifications
 
 
 ## En cours
+...
+
+
+## [4.5] - 2026-02-04
 ### Nouveautés
-- Compléter l'implémentation de CrueConfigMetier
+- Complétion implémentation de CrueConfigMetier
+- Ajout d'utilitaires (timer, traceback...) pour une utilisation par bibcal_wrapper
+
+### Corrections
+- Remplacement utilisation de trapz qui est déprécié (sur numpy>=2.0.0)
+- Correction id_branche pour crue10_model_for_maps (retours VDU)
+- Utilisation librairie standard xml au lieu de lxml pour la lecture/écriture des fichiers Crue10 (éviter plantages sur QGIS selon la version lxml, mauvaise gestion de la mémoire à priori). lxml reste une dépendance nécessaire pour la validation XSD.
 
 
 ## [4.4] - 2025-06-04

--- a/crue10/modele.py
+++ b/crue10/modele.py
@@ -3,11 +3,11 @@ from builtins import super  # Python2 fix
 from collections import Counter, OrderedDict
 from copy import deepcopy
 import fiona
-from lxml import etree
 import numpy as np
 import os.path
 import pandas as pd
 from shapely.geometry import LineString, mapping, Point
+import xml.etree.ElementTree as ET
 
 from crue10.base import EnsembleFichiersXML
 from crue10.emh.branche import Branche, BrancheOrifice, BrancheBarrageFilEau, BrancheBarrageGenerique
@@ -371,7 +371,7 @@ class Modele(EnsembleFichiersXML):
         pdt_elt = self._get_pnum_CalcPseudoPerm().find(PREFIX + 'Pdt')
         pdtcst_elt = pdt_elt.find(PREFIX + 'PdtCst')
         if pdtcst_elt is None:
-            logger.debug(etree.tostring(pdt_elt))
+            logger.debug(ET.tostring(pdt_elt))
             raise ExceptionCrue10("Le pas de temps n'est pas constant")
         return duration_iso8601_to_seconds(pdtcst_elt.text)
 
@@ -383,7 +383,7 @@ class Modele(EnsembleFichiersXML):
         pdt_elt = self._get_pnum_CalcTrans().find(PREFIX + 'Pdt')
         pdtcst_elt = pdt_elt.find(PREFIX + 'PdtCst')
         if pdtcst_elt is None:
-            logger.debug(etree.tostring(pdt_elt))
+            logger.debug(ET.tostring(pdt_elt))
             raise ExceptionCrue10("Le pas de temps n'est pas constant")
         return duration_iso8601_to_seconds(pdtcst_elt.text)
 
@@ -517,7 +517,7 @@ class Modele(EnsembleFichiersXML):
         for elt in pdt_elt:
             pdt_elt.remove(elt)
         # Add new single element
-        sub_elt = etree.SubElement(pdt_elt, PREFIX + 'PdtCst')
+        sub_elt = ET.SubElement(pdt_elt, PREFIX + 'PdtCst')
         sub_elt.text = duration_seconds_to_iso8601(value)
 
     def set_pnum_CalcTrans_PdtCst(self, value):
@@ -534,7 +534,7 @@ class Modele(EnsembleFichiersXML):
         for elt in pdt_elt:
             pdt_elt.remove(elt)
         # Add new single element
-        sub_elt = etree.SubElement(pdt_elt, PREFIX + 'PdtCst')
+        sub_elt = ET.SubElement(pdt_elt, PREFIX + 'PdtCst')
         sub_elt.text = duration_seconds_to_iso8601(value)
 
     def renommer(self, nom_modele_cible, folder):
@@ -764,7 +764,7 @@ class Modele(EnsembleFichiersXML):
                 elt_Pm_TolNdZ = interpol_st_venant.find(PREFIX + 'Pm_TolNdZ')
                 elt_Pm_TolNdZ.tail += '  '
                 # Parameter `Pm_TolStQ` is added (it was in CCM before)
-                elt_Pm_TolStQ = etree.SubElement(interpol_st_venant, PREFIX + 'Pm_TolStQ')
+                elt_Pm_TolStQ = ET.SubElement(interpol_st_venant, PREFIX + 'Pm_TolStQ')
                 elt_Pm_TolStQ.text = float2str(CCM.variable['Pm_TolStQ'].dft)
                 elt_Pm_TolStQ.tail = '\n    '
 

--- a/crue10/run/__init__.py
+++ b/crue10/run/__init__.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from datetime import datetime
 from glob import glob
 from io import open
-from lxml import etree
 import numpy as np
 import os.path
 import subprocess
@@ -11,10 +10,10 @@ import subprocess
 from crue10.run.resultats_calcul import ResultatsCalcul
 from crue10.utils.settings import CRUE10_EXE_PATH
 from crue10.run.trace import Trace
-from crue10.utils import add_default_missing_metadata, check_xml_file, DATA_FOLDER_ABSPATH, ExceptionCrue10, logger
+from crue10.utils import add_default_missing_metadata, check_xml_file, ExceptionCrue10, logger
 from crue10.utils.crueconfigmetier import CCM
 from crue10.utils.settings import GRAVITE_AVERTISSEMENT, GRAVITE_MAX, GRAVITE_MIN, \
-    GRAVITE_MIN_ERROR, GRAVITE_MIN_ERROR_BLK, XML_ENCODING
+    GRAVITE_MIN_ERROR, GRAVITE_MIN_ERROR_BLK
 
 
 FMT_RUN_IDENTIFIER = "R%Y-%m-%d-%Hh%Mm%Ss"


### PR DESCRIPTION
### Nouveautés
- Complétion implémentation de CrueConfigMetier
- Ajout d'utilitaires (timer, traceback...) pour une utilisation par bibcal_wrapper

### Corrections
- Remplacement utilisation de trapz qui est déprécié (sur numpy>=2.0.0)
- Correction id_branche pour crue10_model_for_maps (retours VDU)
- Utilisation librairie standard xml au lieu de lxml pour la lecture/écriture des fichiers Crue10 (éviter plantages sur QGIS selon la version lxml, mauvaise gestion de la mémoire à priori). lxml reste une dépendance nécessaire pour la validation XSD.